### PR TITLE
Fix build for json example

### DIFF
--- a/json/src/main.rs
+++ b/json/src/main.rs
@@ -110,14 +110,14 @@ fn main() {
             .middleware(middleware::Logger::default())
             .resource("/extractor", |r| {
                 r.method(http::Method::POST)
-                    .with_config(extract_item, |cfg| {
+                    .with_config(extract_item, |(cfg,)| {
                         cfg.limit(4096); // <- limit size of the payload
                     })
             })
             .resource("/extractor2", |r| {
                 r.method(http::Method::POST)
-                    .with_config(extract_item_limit, |cfg| {
-                        cfg.0.limit(4096); // <- limit size of the payload
+                    .with_config(extract_item_limit, |((cfg, _),)| {
+                        cfg.limit(4096); // <- limit size of the payload
                     })
             })
             .resource("/manual", |r| r.method(http::Method::POST).f(index_manual))


### PR DESCRIPTION
When I raised #39 the Travis build was failing. This is a fix that makes it pass.

There were a couple of ways to fix this, I went for the "destructured arguments" approach. Another would have been something like:

```rust
   (cfg.0).0.limit(4096); // <- limit size of the payload
```

I felt the destructuring communicated more about what the closure argument looks like. Let me know if there's a better approach.